### PR TITLE
fix: Insert newline at cursor position for Alt+Enter and Ctrl+J

### DIFF
--- a/component/input/chatinput/chatinput.go
+++ b/component/input/chatinput/chatinput.go
@@ -555,8 +555,9 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (bool, tea.Cmd) {
 		return true, m.handleSubmit()
 
 	case msg.Type == tea.KeyEnter && msg.Alt, msg.Type == tea.KeyCtrlJ:
-		m.textarea.SetValue(m.textarea.Value() + "\n")
-		return true, nil
+		var cmd tea.Cmd
+		m.textarea, cmd = m.textarea.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		return true, cmd
 
 	case msg.Type == tea.KeyEsc:
 		m.textarea.SetValue("")

--- a/component/input/chatinput/chatinput_test.go
+++ b/component/input/chatinput/chatinput_test.go
@@ -200,6 +200,27 @@ func TestModel_Update_CtrlJ_InsertsNewline(t *testing.T) {
 	}
 }
 
+func TestChatInput_Newline_AtCursorPosition(t *testing.T) {
+	m := chatinput.New()
+	m.Focus()
+	m.SetValue("helloworld")
+
+	// Move cursor left 5 times to position between "hello" and "world"
+	for range 5 {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+		m = updated.(chatinput.Model)
+	}
+
+	// Press Alt+Enter to insert newline at cursor
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
+	model := updated.(chatinput.Model)
+
+	value := model.Value()
+	if value != "hello\nworld" {
+		t.Errorf("Value() = %q after Alt+Enter mid-text, want %q", value, "hello\nworld")
+	}
+}
+
 func TestChatInput_Clear(t *testing.T) {
 	m := chatinput.New()
 	m.Focus()


### PR DESCRIPTION
## Summary

- Alt+Enter and Ctrl+J now insert a newline at the cursor position instead of always appending at the end of the buffer
- Delegates to textarea's built-in `splitLine` via `Update()` for correct cursor-aware insertion

## Test plan

- [x] `make check` passes (fmt, vet, lint, test)
- [x] Existing newline tests pass (end-of-buffer case)
- [x] New `TestChatInput_Newline_AtCursorPosition` verifies mid-text cursor insertion