### PR TITLE
refactor: Rewrite /tdd and /tdd-review to use team-based agent orchestration

### DIFF
--- a/.claude/commands/tdd-review.md
+++ b/.claude/commands/tdd-review.md
@@ -1,35 +1,44 @@
 ---
-description: Comprehensive code review using parallel specialized agents for TUI components and SDK integration
-allowed-tools: Read, Grep, Glob, Bash(go vet:*), Bash(golangci-lint run:*), Bash(go test:*), Bash(git diff:*), Task
+description: Comprehensive code review using team-based specialized agents with self-coordination
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Task, WebFetch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion
 ---
 
-# TDD Code Review
+# TDD Code Review (Team-Based)
 
-Comprehensive code review using parallel specialized agents. This command orchestrates multiple reviewers to analyze code quality, TUI patterns, error handling, and test coverage.
+Comprehensive code review using team-based specialized agents with self-coordination. Orchestrates multiple reviewers to analyze code quality, TUI patterns, error handling, and test coverage.
+
+## Quick Mode Exception
+
+For focused reviews, use a single bare Agent call (model: "sonnet") with NO team:
+- `--quick` - Only grumpy-gopher
+- `--component` - Only tui-component-reviewer
+- `--errors` - Only silent-failure-hunter
+
+If `$ARGUMENTS` contains any of these flags, extract the flag, launch the single appropriate agent with the file list, present results, and stop. Do not create a team.
+
+---
 
 ## Review Scope Detection
 
 Determine what code to review:
 
-1. **User-specified files**: If user provided specific files or packages, use those
-2. **Recent changes**: Otherwise, check `git diff` for uncommitted changes
-3. **Staged changes**: Check `git diff --staged` for staged changes
-4. **Default**: Review current package if no changes detected
+1. **User-specified files**: If user provided specific files or packages after the flag/arguments, use those
+2. **Unstaged changes**: `git diff --name-only`
+3. **Staged changes**: `git diff --staged --name-only`
+4. **Default**: Current package (`./...`)
 
 ```bash
-# Check for changes
-git status --porcelain
 git diff --name-only
 git diff --staged --name-only
 ```
 
-Store the list of files to review.
+Store the file list. If no files found, report and exit.
 
 ---
 
 ## Reviewer Selection
 
-Based on files identified, determine which reviewers to launch:
+Based on files identified, select reviewers:
 
 | File Pattern | Reviewer |
 |--------------|----------|
@@ -39,199 +48,140 @@ Based on files identified, determine which reviewers to launch:
 | `adapter/*` | sdk-adapter-reviewer |
 | `style/*` | tui-component-reviewer |
 | `*_test.go` | pr-test-analyzer |
-| Any Go file | grumpy-gopher, silent-failure-hunter |
+| Any Go file | grumpy-gopher |
+| Any Go file | silent-failure-hunter |
 
-**Always include**: grumpy-gopher, silent-failure-hunter
+**Always include**: grumpy-gopher, silent-failure-hunter (for any Go files).
 
----
-
-## Phase 1: Launch Parallel Review Agents
-
-Launch up to 3 review agents IN PARALLEL using the Task tool:
-
-### Agent 1: Component/Adapter Reviewer
-
-If TUI component files detected, launch **tui-component-reviewer**:
-```
-Review the following TUI component files for Bubble Tea patterns:
-
-Files to review:
-[List of component files]
-
-Focus on:
-- Model struct correctness
-- Init/Update/View implementation
-- Message type design
-- Focus management (for input components)
-- Lip Gloss styling consistency
-- Functional options pattern
-
-Provide findings in severity-categorized table format.
-```
-
-If adapter files detected, launch **sdk-adapter-reviewer**:
-```
-Review the following SDK adapter files:
-
-Files to review:
-[List of adapter files]
-
-Focus on:
-- Stream event conversion
-- Channel and goroutine safety
-- Error propagation
-- Client lifecycle management
-
-Provide findings in severity-categorized table format.
-```
-
-### Agent 2: Go Expert Reviewer (grumpy-gopher)
-
-```
-Review the following Go files for best practices and idioms:
-
-Files to review:
-[List of all Go files]
-
-Focus on:
-- Go idioms and best practices
-- Error handling patterns
-- Interface design
-- Resource management
-- Naming conventions
-
-Be thorough and technical. Apply your grumpy personality after analysis.
-```
-
-### Agent 3: Error Handling Reviewer (silent-failure-hunter)
-
-```
-Analyze error handling in the following files:
-
-Files to review:
-[List of all Go files]
-
-Hunt for:
-- Silent failures (errors swallowed)
-- Empty catch blocks or ignored errors
-- Inappropriate fallback behavior hiding problems
-- Errors logged but not propagated
-- Missing error checks on function returns
-- Update handlers ignoring error messages
-
-Report all findings with file:line references and severity.
-```
-
-**WAIT for all agents to complete.**
+Deduplicate: if tui-component-reviewer would be selected multiple times, launch once with all matching files.
 
 ---
 
-## Phase 2: Compile Results
+## Phase 1: Team Creation & Spawn
 
-Aggregate findings from all reviewers:
+### Create Team
 
-1. **Collect all issues** from each agent
-2. **Deduplicate** - Same issue reported by multiple agents
+Generate a short ID from timestamp or random suffix:
+```
+TeamCreate(team_name="review-{short-id}", description="Code review for [file summary]")
+```
+
+### Create Review Tasks
+
+One task per selected reviewer. No dependencies - all run in parallel.
+
+Example:
+```
+Task 1: "Review: TUI component patterns" (files: component/output/streamtext/...)
+Task 2: "Review: Go idioms and best practices" (files: [all Go files])
+Task 3: "Review: Error handling and silent failures" (files: [all Go files])
+Task 4: "Review: Test coverage analysis" (files: [test files])
+```
+
+Each task description includes: reviewer type, file list, focus areas.
+
+### Spawn Reviewers
+
+All reviewers use `model: "sonnet"`. Each gets this inline prompt:
+
+```
+You are a reviewer on team review-{short-id}.
+
+Self-coordination loop:
+1. Call TaskList for unblocked, unassigned review tasks
+2. Claim lowest-ID matching task via TaskUpdate (set owner to your name)
+3. Read task description via TaskGet for file list and focus areas
+4. Execute review per your methodology
+5. Send findings to lead via SendMessage in this format:
+   - CRITICAL: [issues that must fix - bugs, security, data loss]
+   - MAJOR: [should fix - significant quality issues]
+   - MINOR: [nice to fix - style, minor improvements]
+   - POSITIVE: [good patterns observed]
+6. Mark task completed via TaskUpdate
+7. Check TaskList for more work. If none: message lead "Review complete. Standing by."
+
+Restrictions:
+- NEVER use TeamCreate, TeamDelete, or broadcast
+- NEVER modify source code - review only
+- Report ALL findings with file:line references
+```
+
+---
+
+## Phase 2: Collect Results
+
+Wait for all reviewer messages. As each arrives:
+
+1. **Collect findings** from each reviewer message
+2. **Deduplicate** - same issue reported by multiple reviewers (keep the most detailed)
 3. **Categorize by severity**:
-   - **Critical**: Must fix before merge (bugs, security, data loss)
+   - **Critical**: Must fix (bugs, security, data loss)
    - **Major**: Should fix (significant quality issues)
    - **Minor**: Nice to fix (style, minor improvements)
 
 ---
 
-## Phase 2.5: Filter MVP-Scoped Issues
+## Phase 3: Filter MVP-Scoped Issues
 
-Before presenting results, filter out issues that will be addressed by other MVP GitHub issues:
+Before presenting, filter out issues tracked elsewhere:
 
-### Check GitHub Issues First
-
-Query open MVP issues to understand planned work:
+### Check GitHub Issues
 
 ```bash
-# List MVP-labeled issues
 gh issue list --label MVP --state open --json number,title,body --limit 50
-
-# Search for specific feature mentions
-gh issue list --search "adapter" --state open --json number,title
 ```
-
-Cross-reference review findings against open issues. If a finding is already tracked, note the issue number and filter it.
 
 ### Filtering Criteria
 
-**FILTER OUT** issues that match:
+**FILTER OUT** if:
+1. **Tracked in GitHub Issues** (MVP label) - already planned. Note: "Tracked in #123"
+2. **Planned in docs/** - features documented as future work
+3. **Example/demo code** (`example/` directory) - unless misleading for library users
+4. **Documentation-only** - missing docs for planned features
+5. **Test infrastructure** - test helpers that ship with their feature
 
-1. **Tracked in GitHub Issues (MVP label)** - Already planned work
-   - Run `gh issue list --label MVP` to get current MVP scope
-   - If finding matches an open issue, note: "Tracked in #123"
-   - Example: "Missing ToolResultMsg" - if Issue #15 covers this, filter out
-
-2. **Planned features documented in `docs/`** - Features explicitly marked as planned/future work
-   - Check `docs/ADAPTERS.md`, `docs/ROADMAP.md` for planned components
-   - Example: "Missing TaskStartedMsg type" - if documented as planned, filter out
-
-3. **Example/demo code issues** - Issues in `example/` directory that don't affect core library
-   - Example app is for validation, not production use
-   - Filter unless the issue would mislead users about library usage
-
-4. **Documentation-only changes** - Issues about missing docs for planned features
-
-5. **Test infrastructure** - Issues about test helpers that will be added with their features
-
-### How to Filter
-
-For each issue, check:
-```
-1. Is this tracked in OR directly supports a GitHub MVP issue? -> FILTER (note issue #)
-2. Is this in docs/ as planned work? -> FILTER
-3. Is this in example/ and non-critical? -> FILTER
-4. Does this block current branch functionality? -> KEEP
-5. Is this a code quality issue in core library? -> KEEP
-```
-
-**"Directly supports"** means the finding relates to functionality that an MVP issue depends on or enables, even if not explicitly mentioned in that issue. Use judgment - if fixing this finding would be part of completing an MVP issue, filter it.
+**KEEP** if:
+- Blocks current branch functionality
+- Code quality issue in core library code
+- Security or correctness issue regardless of location
 
 ### Present Filtered List
 
-After filtering, ask user to confirm:
 ```
-FILTERED ISSUES (will be addressed by other MVP work):
-- [Issue 1] - Reason: Documented in docs/ADAPTERS.md as Phase 2
-- [Issue 2] - Reason: Example app only, not core library
+FILTERED ISSUES (addressed by other planned work):
+- [Issue description] - Reason: Tracked in #123
+- [Issue description] - Reason: Planned in docs/ROADMAP.md
 
-Proceed with remaining [N] issues? [Y/n]
+Proceed with remaining [N] issues?
 ```
+
+Use AskUserQuestion to confirm.
 
 ---
 
-## Phase 3: Present Summary
-
-Display aggregated results in table format:
+## Phase 4: Present Summary
 
 ```
 CODE REVIEW SUMMARY
 ===================
 
 Files Reviewed: X
-Reviewers: tui-component-reviewer, grumpy-gopher, silent-failure-hunter
+Reviewers: [list of reviewer types used]
 
 CRITICAL ISSUES (Must Fix)
 --------------------------
 | Issue | Location | Reviewer | Recommended Fix |
 |-------|----------|----------|-----------------|
-| ...   | file:line | ...     | ...             |
 
 MAJOR ISSUES (Should Fix)
 -------------------------
 | Issue | Location | Reviewer | Recommended Fix |
 |-------|----------|----------|-----------------|
-| ...   | file:line | ...     | ...             |
 
 MINOR ISSUES (Nice to Fix)
 --------------------------
 | Issue | Location | Reviewer | Recommended Fix |
 |-------|----------|----------|-----------------|
-| ...   | file:line | ...     | ...             |
 
 POSITIVE OBSERVATIONS
 ---------------------
@@ -249,65 +199,58 @@ Production Ready: [Yes/No - with explanation]
 
 ---
 
-## Phase 4: Offer Fixes
+## Phase 5: Offer Fixes
 
-If issues were found, ask user:
+If issues were found, present options via AskUserQuestion:
 
-1. **Fix all issues** - Automatically apply fixes for all issues
-2. **Fix critical only** - Only fix critical issues
-3. **Fix selected** - Let user choose which to fix
-4. **Skip fixes** - Don't fix, just report
+1. **Fix all issues** - Apply fixes for all severities
+2. **Fix critical only** - Only address critical issues
+3. **Fix selected** - User chooses which to fix
+4. **Skip fixes** - Report only, no changes
 
 If user chooses to fix:
-
 1. Apply fixes using Edit tool
-2. Run `go fmt ./...` and `go vet ./...`
-3. Run tests to verify fixes don't break anything
-4. Report what was fixed
+2. Run `make check` to verify fixes
+3. Report what was fixed and verify no regressions
 
 ---
 
-## Phase 5: Re-review (Optional)
+## Phase 6: Re-review (Optional)
 
-After fixes are applied, offer to re-run review:
+After fixes applied, offer via AskUserQuestion:
 
-```
-Fixes applied. Would you like to re-run the review to verify all issues are resolved?
+1. **Yes** - Re-run full review (loop back to Phase 1 with same team if still active)
+2. **No** - Trust the fixes, proceed to cleanup
 
-1. Yes - Run full review again
-2. No - Trust the fixes, we're done
-```
-
-If yes, loop back to Phase 1 with the fixed files.
+If re-reviewing with existing team:
+- Create new review tasks for fixed files only
+- Message existing reviewers (if still active) or spawn new ones
+- Collect and present delta results
 
 ---
 
-## Quick Review Mode
+## Team Cleanup
 
-For fast reviews (less thorough), user can specify:
-- `/tdd-review --quick` - Only run grumpy-gopher
-- `/tdd-review --component` - Only run tui-component-reviewer
-- `/tdd-review --errors` - Only run silent-failure-hunter
-
-Default is full review with all agents.
+1. Send `shutdown_request` to each reviewer, wait for confirmations
+2. `TeamDelete` to clean up team and task directories
+3. Verify directories are removed
 
 ---
 
 ## Integration with /tdd
 
-The `/tdd` command uses this review workflow in Phase 5. When called from `/tdd`:
-
-1. Review is BLOCKING - must pass before PR
-2. Critical/Major issues trigger fix loop
-3. No user interaction for severity selection - all issues must be fixed
+When called from `/tdd` command (Phase 4a):
+- Review is BLOCKING - must pass before PR creation
+- Critical/major issues trigger fix loop automatically
+- No user interaction for severity selection - all issues must be addressed
+- Findings sent back to lead via SendMessage (not presented as summary table)
 
 ---
 
 ## Error Handling
 
-If review fails:
-
-1. **Agent timeout**: Report which agent timed out, continue with others
-2. **No files to review**: Report and exit gracefully
-3. **Git errors**: Report git state issue, suggest fix
-4. **Fix application fails**: Report error, show manual fix instructions
+- **Agent timeout**: Report which reviewer timed out, continue with others' results
+- **No files to review**: Report and exit gracefully, no team created
+- **Git errors**: Report git state issue, suggest fix
+- **Fix application fails**: Report error, show manual fix instructions
+- **Team exists**: If `review-{short-id}` already exists, generate new ID and retry

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -1,11 +1,12 @@
 ---
 argument-hint: <issue-number>
-description: Autonomous TDD development cycle with orchestrated subagents for TUI components
+description: Autonomous TDD team with task-list-driven self-coordination - scales to scope, reviewers as teammates
+allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Task, WebFetch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion, EnterPlanMode, ExitPlanMode
 ---
 
-# TDD Development Cycle
+# TDD Development Cycle (Team-Based)
 
-Execute complete TDD workflow for GitHub issue `$ARGUMENTS` with built-in quality gates and subagent orchestration.
+Execute complete TDD workflow for GitHub issue `$ARGUMENTS` using team-based agent orchestration with self-coordinating teammates.
 
 ## Input Validation
 
@@ -16,390 +17,324 @@ Parse argument as GitHub issue number:
 
 ---
 
-## Phase 1: Pre-flight Checks
+## Phase 1: Preflight Checks
 
 Verify the development environment is ready:
 
-1. **Check working directory status** - Run `git status` to ensure no uncommitted changes
-2. **Verify current branch** - Should be on `main` branch
-3. **Pull latest changes** - Run `git pull` to sync with remote
-4. **Check for existing PRs** - Run `gh pr list --search "issue:$ARGUMENTS"` to avoid duplicate work
-5. **Verify Go environment** - Run `go version` and ensure toolchain is available
-6. **Check for blocking issues** - Look for "Depends on" or "Blocked by" in issue body
+1. **Working directory** - `git status` must show clean working tree
+2. **Current branch** - Must be on `main`
+3. **Pull latest** - `git pull` to sync with remote
+4. **Existing PRs** - `gh pr list --search "issue:$ARGUMENTS"` to avoid duplicates
+5. **Go environment** - `go version` confirms toolchain available
+6. **Blocking issues** - Check issue body for "Depends on" or "Blocked by"
 
-**STOP and report to user if any check fails** - Don't proceed until issues are resolved.
-
----
-
-## Phase 2: Task Validation
-
-Fetch and validate the GitHub issue:
-
-1. **Fetch issue details**:
-   ```bash
-   gh issue view $ARGUMENTS --json title,body,labels,state,comments
-   ```
-
-2. **Validate issue**:
-   - Issue must exist and be open
-   - Issue must have a clear description or acceptance criteria
-
-3. **Extract requirements**:
-   - Title (feature/fix description)
-   - Body (detailed requirements)
-   - Labels (component type: output, input, adapter, layout)
-   - Comments (any additional context or decisions)
-
-**If incomplete:** Report gaps to user and ask if should proceed anyway.
-**If complete:** Display issue summary and continue.
+**STOP and report if any check fails.**
 
 ---
 
-## Phase 3: Discovery & Planning
+## Phase 2: Discovery & Planning
 
-### Codebase Exploration (Automated)
+### Enter Plan Mode
 
-Launch 3 Explore agents IN PARALLEL using the Task tool:
+Use EnterPlanMode to begin planning.
 
-**Agent 1 - Local Pattern Discovery:**
-```
-Explore the claude-agent-tui codebase for patterns relevant to this task:
+### Fetch Issue
 
-**IMPORTANT: Read skill references first for framework patterns:**
-- Read .claude/skills/charmbracelet/SKILL.md for Bubble Tea best practices
-- Read relevant reference files in .claude/skills/charmbracelet/references/
-
-Project structure:
-- component/output/ - Display components (StreamText, MessageBubble, etc.)
-- component/input/ - Input components (ChatInput, PermissionPrompt, etc.)
-- layout/ - Composite screens
-- adapter/ - SDK integration layer
-- style/ - Lip Gloss defaults
-
-Search for:
-- Similar component implementations in component/
-- Bubble Tea model patterns (Init, Update, View)
-- Lip Gloss styling patterns in style/
-- Functional options patterns (WithStyles, WithXxx)
-
-Use ast-grep for structural search:
-- Find Model structs: ast-grep --pattern 'type Model struct { $$$ }' --lang go
-- Find Update methods: ast-grep --pattern 'func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { $$$ }' --lang go
-
-Report patterns found that should be followed for this implementation.
-```
-
-**Agent 2 - Test Conventions:**
-```
-Explore testing patterns in claude-agent-tui:
-
-Search for:
-- Existing test files (*_test.go)
-- Table-driven test patterns
-- teatest usage for TUI component testing
-- Golden file patterns for ANSI output verification
-- Test helpers and fixtures
-
-Use ast-grep:
-- Find test functions: ast-grep --pattern 'func Test$NAME(t *testing.T) { $$$ }' --lang go
-- Find subtests: ast-grep --pattern 't.Run($NAME, func($$$) { $$$ })' --lang go
-
-Report testing conventions that should be followed.
-```
-
-**Agent 3 - SDK Integration Patterns:**
-```
-Explore SDK integration patterns relevant to this task:
-
-**IMPORTANT: Read skill references first for SDK patterns:**
-- Read .claude/skills/claude-agent-sdk-go/SKILL.md for SDK best practices
-- Read relevant reference files in .claude/skills/claude-agent-sdk-go/references/
-
-Check adapter/ directory for:
-- Stream event to tea.Msg conversion patterns
-- Hook callback handling
-- Client lifecycle management
-- Error propagation patterns
-
-Check ../claude-code-sdk-go/ for:
-- Message types to handle
-- Client API usage
-- Functional options available
-
-Report integration patterns that apply to this implementation.
-```
-
-**WAIT for all 3 agents to complete before proceeding.**
-
-### Architecture Planning (Automated)
-
-Launch 1 Plan agent with context from the Explore agents:
-
-```
-Design a TDD implementation plan for GitHub issue #$ARGUMENTS:
-
-Issue Details:
-[Insert issue title, body, requirements from Phase 2]
-
-Context from Exploration:
-- Local Patterns: [Agent 1 findings]
-- Test Conventions: [Agent 2 findings]
-- SDK Integration: [Agent 3 findings]
-
-Requirements:
-1. Follow existing Bubble Tea patterns in the codebase
-2. Use teatest with golden files for ANSI verification
-3. Match styling patterns in style/
-4. Follow functional options pattern
-
-Provide a detailed TDD plan structured as:
-
-## RED Phase - Tests First
-- List specific test cases to write
-- Include table-driven test structure
-- Include edge cases (nil, empty, error conditions)
-- Specify golden file tests for visual output
-
-## GREEN Phase - Implementation
-- List files to create/modify
-- Describe Model struct fields needed
-- Describe messages to define
-- Describe Init/Update/View implementations
-
-## BLUE Phase - Refactoring
-- Quality improvements to apply
-- Pattern alignment checks
-
-## Acceptance Criteria Mapping
-- Map each requirement to specific test cases
-```
-
-### Critical Checkpoint: User Approval
-
-**Use ExitPlanMode tool to present the plan and await user approval.**
-
-Do NOT continue to Phase 4 until user approves the plan.
-
----
-
-## Phase 4: TDD Implementation
-
-**Delegate to tdd-implementer agent** using the Task tool:
-
-```
-Execute TDD implementation for GitHub issue #$ARGUMENTS
-
-## Approved Plan
-[Insert the approved plan from Phase 3]
-
-## Issue Details
-- Title: [Issue title]
-- Requirements: [Issue body/requirements]
-
-## Branch Name
-feature/issue-$ARGUMENTS-[short-description-kebab-case]
-
-## Instructions
-1. Create feature branch from main
-2. Execute RED phase - write failing tests with teatest golden files
-3. Execute GREEN phase - implement to pass tests
-4. Execute BLUE phase - refactor with code-simplifier agent
-5. Push branch to origin
-6. Return: branch name, commit SHAs, test results
-
-Follow the tdd-implementer agent workflow exactly.
-```
-
-**WAIT for tdd-implementer to complete.**
-
-Capture returned:
-- Branch name
-- Commit SHAs (RED, GREEN, BLUE)
-- Test results
-
----
-
-## Phase 5: Automated Code Review
-
-Launch 3 review agents IN PARALLEL using the Task tool (BLOCKING):
-
-### Determine Reviewer Type
-
-Based on files modified:
-- If `component/` modified -> use `tui-component-reviewer`
-- If `adapter/` modified -> use `sdk-adapter-reviewer`
-- If both -> use both reviewers (launch 4 agents total)
-
-### tui-component-reviewer OR sdk-adapter-reviewer Agent
-```
-Review the code changes in branch [branch-name] for TUI component/adapter patterns.
-Focus on files modified in this branch.
-Report issues in severity-categorized format.
-```
-
-### silent-failure-hunter Agent
-```
-Analyze error handling in the code changes on branch [branch-name]:
-- Silent failures where errors are swallowed
-- Inadequate error handling
-- Inappropriate fallback behavior
-- Missing error checks on function returns
-- Bubble Tea Update handlers that ignore error messages
-
-Report all findings with file:line references.
-```
-
-### pr-test-analyzer Agent
-```
-Review test coverage for the code changes on branch [branch-name]:
-- Table-driven tests used for multiple cases
-- Test helpers call t.Helper()
-- Edge cases covered (nil, empty, error conditions)
-- teatest golden files for ANSI verification
-- Tests are deterministic (no flaky tests)
-- Coverage adequate for new functionality
-
-Report gaps and recommendations.
-```
-
-**WAIT for all review agents to complete.**
-
-**BLOCKING GATE**: If ANY agent finds Critical or Major issues:
-1. Compile all findings
-2. Launch tdd-implementer agent again with fix instructions
-3. Re-run review agents
-4. Repeat until all issues resolved
-
----
-
-## Phase 6: Validation
-
-Run full validation suite:
-
-### Test Suite
 ```bash
-go test -cover -race ./...
+gh issue view $ARGUMENTS --json title,body,labels,state,comments
 ```
 
-Verify:
-1. All tests pass
-2. Coverage report acceptable
-3. No race conditions detected
+Validate: issue exists, is open, has clear requirements. Extract title, body, labels, comments.
 
-### Build Check
-```bash
-go build ./...
+### Codebase Exploration
+
+Launch 2 Explore agents IN PARALLEL (model: "sonnet"):
+
+**Agent 1 - Build System & Conventions:**
+```
+Explore claude-agent-tui for build and quality conventions:
+- Read Makefile for targets (make check, make test-race, make test-tui)
+- Read .claude/skills/charmbracelet/SKILL.md for Bubble Tea patterns
+- Identify test framework (teatest, golden files), commit conventions
+- Find existing component patterns: Model structs, Init/Update/View, functional options
+- Report: build commands, quality gates, test patterns, commit prefixes
 ```
 
-Ensure all packages build without errors.
-
-### Linter Check
-```bash
-golangci-lint run
+**Agent 2 - Affected Code & Architecture:**
+```
+Analyze code relevant to issue #$ARGUMENTS:
+- Identify affected files, packages, dependencies
+- Map existing patterns in affected areas
+- Check adapter/ for SDK integration patterns if relevant
+- Check component/ for TUI patterns if relevant
+- Read .claude/skills/claude-agent-sdk-go/SKILL.md if SDK work needed
+- Report: files to modify/create, dependencies, patterns to follow
 ```
 
-Address any linting issues (auto-fix with `go fmt` where possible).
+### Design Task Graph
 
-**STOP if validation fails** - Report issues to user and await instructions.
+After exploration completes, design the implementation plan:
+
+**Task graph structure:**
+```
+RED -> QA RED -> GREEN -> QA GREEN -> Review -> Create PR
+```
+
+- RED: Write failing tests (commit prefix: `test:`)
+- QA RED: Verify existing gates pass, new tests FAIL, no regressions
+- GREEN: Write production-quality code to pass tests (commit prefix: `feat:`)
+- QA GREEN: Run ALL quality gates (make check, make test-race)
+- Review: Specialized code reviewers (lead dispatches JIT)
+- Create PR: Final step (lead-owned)
+
+**Track types based on scope:**
+- **Standard**: RED -> QA RED -> GREEN -> QA GREEN (for new features, complex changes)
+- **Lightweight**: IMPLEMENT -> QA VERIFY (for simple fixes, config changes)
+
+**Multi-issue/multi-track**: Parallel tracks with cross-deps only when files overlap.
+
+**Team composition (determined during planning):**
+- Minimum: 1 implementer + 1 verifier
+- Scale implementers to independent work tracks (max 3)
+- Reviewers: spawned JIT when QA GREEN passes
+
+### Present Plan
+
+Use ExitPlanMode. Do NOT proceed until user approves.
 
 ---
 
-## Phase 7: PR Creation & Merge
+## Phase 3: Team Spawn
 
-### Create Pull Request
+After user approval:
+
+### Setup
+
+1. Sanitize issue number for branch/team names (e.g., `42` -> `tdd-42`)
+2. Create branch: `feature/issue-$ARGUMENTS-[short-description-kebab-case]`
+3. Check for existing team: if `~/.claude/teams/tdd-$ARGUMENTS/` exists, recover (see Error Recovery)
+
+### Create Team
+
+```
+TeamCreate(team_name="tdd-$ARGUMENTS", description="TDD for issue #$ARGUMENTS")
+```
+
+### Create Task Graph
+
+Use TaskCreate for each task, then TaskUpdate to set `addBlockedBy` dependencies.
+
+Example for standard track:
+```
+Task 1: "RED: Write failing tests for [feature]"
+Task 2: "QA RED: Verify test failures" (blockedBy: [1])
+Task 3: "GREEN: Implement [feature]" (blockedBy: [2])
+Task 4: "QA GREEN: Full quality gate verification" (blockedBy: [3])
+Task 5: "Review: Specialized code review" (blockedBy: [4], owner: lead)
+Task 6: "Create PR" (blockedBy: [5], owner: lead)
+```
+
+Each task description includes: what to do, files involved, success criteria.
+
+### Spawn Teammates
+
+All teammates use `model: "sonnet"`. Never use `mode: "plan"`.
+
+**Implementer(s)** - one per independent work track:
+```
+You are an implementer on team tdd-$ARGUMENTS.
+
+Self-coordination loop:
+1. Call TaskList to find unblocked, unassigned tasks
+2. Filter to implementation tasks (RED, GREEN, IMPLEMENT, fix - NOT QA/verify tasks)
+3. Claim lowest-ID matching task via TaskUpdate (set owner to your name)
+4. Read task description via TaskGet for full requirements
+5. Work to completion, commit with appropriate prefix (test: for RED, feat: for GREEN, fix: for iterations)
+6. Mark task completed via TaskUpdate
+7. Message verifier with summary of what was done
+8. Loop back to step 1
+
+If no matching tasks available, message lead: "No available implementation work. Standing by."
+
+Restrictions:
+- NEVER use TeamCreate, TeamDelete, or broadcast
+- NEVER create tasks unilaterally - propose to lead via SendMessage
+- NEVER skip or modify QA/verify tasks
+- Follow project conventions in CLAUDE.md
+```
+
+**Verifier** - one per team:
+```
+You are the verifier on team tdd-$ARGUMENTS.
+
+Self-coordination loop:
+1. Call TaskList to find unblocked, unassigned tasks
+2. Filter to QA/verification tasks (QA, verify, VERIFY)
+3. Claim lowest-ID matching task via TaskUpdate (set owner to your name)
+4. Read task description via TaskGet for full criteria
+5. Run ALL success criteria - report every failure, not just the first
+6. On PASS: mark completed, loop back to step 1
+7. On FAIL: message implementer with specific failures, keep task in_progress
+   - Track iteration count. After 3 failed iterations, escalate to lead
+8. When QA GREEN passes, message lead: "QA GREEN complete for [task description]"
+
+If no matching tasks available, message lead: "No available QA work. Standing by."
+
+QA RED criteria:
+- Existing quality gates pass (make check)
+- New tests FAIL (they must fail before implementation)
+- No regressions in existing tests
+
+QA GREEN criteria:
+- make check passes (fmt, vet, lint, test)
+- make test-race passes (race condition detection)
+- make test-tui passes (golden file tests, if applicable)
+- All new tests pass
+- No regressions
+
+Restrictions:
+- NEVER use TeamCreate, TeamDelete, or broadcast
+- NEVER modify source code - only run verification commands
+- Report ALL failures, not just the first one found
+```
+
+---
+
+## Phase 4: Autonomous Execution
+
+Lead monitoring loop - wait for messages, react:
+
+```
+while shutdown criteria NOT met:
+  wait for next teammate message
+
+  on "QA GREEN complete":
+    -> Dispatch reviews (Phase 4a)
+
+  on review verdicts:
+    -> Process review loop (Phase 4b)
+
+  on escalation (QA iteration >= 3):
+    -> Read failure details, attempt direct fix or ask user
+
+  on task proposal from implementer:
+    -> Evaluate, create task if appropriate, assign back
+
+  on "No available work. Standing by.":
+    -> Check TaskList. If unblocked work exists, point teammate to it.
+    -> If all work genuinely done, acknowledge.
+
+  on idle notification (teammate stopped):
+    -> Normal behavior. Only act if teammate has in_progress tasks.
+```
+
+Teammates self-coordinate via TaskList. Lead does NOT proactively assign unclaimed tasks unless asked.
+
+### Phase 4a: Review Dispatch (JIT)
+
+When verifier messages "QA GREEN complete":
+
+1. Assess diff to determine review scope: `git diff main...HEAD --stat`
+2. Create review tasks via TaskCreate (no dependencies between reviewers - all parallel)
+3. Spawn reviewer teammates (model: "sonnet"), selecting based on modified files:
+
+| Modified Path | Reviewer Agent Type |
+|---------------|---------------------|
+| `component/` | tui-component-reviewer |
+| `adapter/` | sdk-adapter-reviewer |
+| Any Go file | grumpy-gopher |
+| Any Go file | silent-failure-hunter |
+| `*_test.go` | pr-test-analyzer |
+
+Each reviewer gets this inline prompt:
+```
+You are a reviewer on team tdd-$ARGUMENTS.
+
+1. Call TaskList, claim your review task via TaskUpdate
+2. Execute review per your methodology on the files listed in the task
+3. Send findings to lead via SendMessage with severity categories
+4. Mark task completed via TaskUpdate
+5. If no more work, message lead: "Review complete. Standing by."
+
+Restrictions: NEVER use TeamCreate, TeamDelete, or broadcast
+```
+
+4. Wait for all reviewer messages
+
+### Phase 4b: Review Loop
+
+When reviewers report findings:
+
+1. If all reviewers report no critical/major issues -> mark "Review" task complete
+2. If critical/major issues found:
+   a. Message implementer with consolidated findings
+   b. Implementer fixes and commits (prefix: `fix:` or `refactor:`)
+   c. Create "QA regression" task for verifier (blockedBy: implementer's fix)
+   d. After QA passes, reviewer re-checks
+   e. If review iteration >= 3: escalate to user with full context
+3. Review iteration budgets: 3 per review loop (independent from QA iteration budget)
+
+### Shutdown Criteria
+
+ALL must be true:
+1. Every task in TaskList is completed
+2. No teammates have in_progress tasks
+3. Final verification: `make check && make test-race`
+
+---
+
+## Phase 5: PR Creation & Cleanup
+
+### Create PR
 
 ```bash
 gh pr create --title "feat: [Issue Title]" --body "$(cat <<'EOF'
 ## Summary
-[1-2 sentence overview of changes]
-
-## Issue Reference
-Closes #$ARGUMENTS
-
-## Changes
-
-### Files Created
-- `path/to/file.go` - Description
-
-### Files Modified
-- `path/to/file.go` - What changed
+[1-3 bullet points from implementation]
 
 ## Test Plan
-- [x] All tests passing
-- [x] Coverage maintained/improved
-- [x] Race detector clean
-- [x] Build succeeds
-- [x] Linter clean
+- [x] TDD RED: Tests written first, verified failing
+- [x] TDD GREEN: Implementation passes all tests
+- [x] Quality gates: make check, make test-race
+- [x] Code review: [list reviewers that participated]
 
-## TDD Cycle
-- RED: [commit SHA] - Tests written first
-- GREEN: [commit SHA] - Implementation added
-- BLUE: [commit SHA] - Refactored (if applicable)
+## Review Summary
+[Key findings addressed, reviewer verdicts]
+
+Closes #$ARGUMENTS
 EOF
 )"
 ```
 
-### Interactive Checkpoint: PR Review
+### Team Cleanup
 
-Display PR URL to user and present options:
+1. Send `shutdown_request` to each teammate, wait for confirmations
+2. `TeamDelete` to clean up team and task directories
+3. Verify `~/.claude/teams/tdd-$ARGUMENTS/` and `~/.claude/tasks/tdd-$ARGUMENTS/` are gone
 
-1. **Approve** - Proceed to merge
-2. **Request changes** - Wait for user edits
-3. **Reject** - Close PR and rollback
-
-### After User Approval: Merge PR
-
-```bash
-gh pr merge --squash --delete-branch
-git checkout main
-git pull
-```
-
----
-
-## Completion Summary
-
-Display final summary:
-
-```
-TDD Development Cycle Complete for Issue #$ARGUMENTS
-
-Phase 1: Pre-flight Checks - Done
-Phase 2: Task Validation - Done
-Phase 3: Discovery & Planning (User Approved) - Done
-Phase 4: TDD Implementation (via tdd-implementer) - Done
-  - RED: Tests written with teatest golden files
-  - GREEN: Implementation complete
-  - BLUE: Refactored (if applicable)
-Phase 5: Automated Code Review - Done
-  - Component/Adapter review: Passed
-  - Silent failure hunt: Passed
-  - Test coverage analysis: Passed
-Phase 6: Validation - Done
-Phase 7: PR Merged - Done
-
-PR: #[number] (merged and branch deleted)
-Issue: #$ARGUMENTS (closed)
-Branch: main (updated)
-
-Test Results:
-- Tests: X passed
-- Coverage: XX%
-- Race conditions: None
-```
+### Present PR URL to user
 
 ---
 
 ## Error Recovery
 
-If any phase fails:
+**Preflight failures**: Report to user, provide fix suggestions, stop.
 
-1. **Pre-flight Failures**: Report to user, provide fix suggestions, stop
-2. **Issue Not Found**: Report error, stop
-3. **Planning Rejected**: Ask user for guidance, revise plan
-4. **TDD Failures**: tdd-implementer handles internally
-5. **Review Failures**: Loop back to fix and re-review
-6. **Validation Failures**: Report issues, offer to fix
-7. **PR Failures**: Report error, provide manual commands
+**Issue not found**: Report error, stop.
 
-**Branch is preserved on failure** - User can manually inspect and continue.
+**Planning rejected**: Revise plan based on user feedback, re-present.
+
+**Unresponsive teammate**: Ping via SendMessage. If no response after 2 pings, escalate to user.
+
+**Repeated QA failures** (iteration >= 3): Include full test output in escalation to user.
+
+**Reviewer disagreement**: Attempt resolution via messages. If deadlocked after 2 rounds, escalate to user.
+
+**Lead fallback**: If implementer stuck after 2 messages, lead writes fix directly and commits.
+
+**Session recovery**: If team directory exists from previous run:
+1. Read TaskList for last-known state
+2. Reset stale `in_progress` tasks (no owner or owner gone) to `pending`
+3. Spawn fresh teammates to continue from current state
+
+**Branch preserved on failure** - user can manually inspect and continue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 - **Module**: `github.com/severity1/claude-agent-tui`
 - **Go Version**: 1.24+
 - **Core Dependencies**: Bubble Tea, Lip Gloss, Bubbles, claude-agent-sdk-go
-- **Status**: Stream adapter and streamtext component implemented, additional components in planning phase
+- **Status**: Stream adapter, streamtext (output), and chatinput (input) components implemented; layout components in planning phase
 
 <!-- END AUTO-MANAGED -->
 
@@ -64,7 +64,12 @@ claude-agent-tui/
 │   └── doc.go                    # Package documentation
 │
 ├── component/                    # TUI components
-│   ├── input/                    # Input components (planned)
+│   ├── input/                    # Input components
+│   │   └── chatinput/            # Chat input with history and clipboard
+│   │       ├── chatinput.go      # Component implementation
+│   │       ├── chatinput_test.go # Comprehensive tests
+│   │       ├── styles.go         # Styles struct and palette integration
+│   │       └── doc.go            # Package documentation
 │   └── output/                   # Display components
 │       └── streamtext/           # Streaming text with cursor
 │           ├── streamtext.go     # Component implementation
@@ -247,6 +252,18 @@ Message events: `message_start`, `message_delta`, `message_stop`
 - Only `StreamDoneMsg` and `StreamErrorMsg` should NOT return `StreamCmd` (they signal end of stream)
 - Pattern: `case adapter.XxxMsg: /* handle */ return m, adapter.StreamCmd(m.ctx, m.msgChan)`
 - See `example/client/main.go` for comprehensive implementation with both streaming and complete message types
+
+### ChatInput Component Pattern
+- **Key-event-controlled**: Unlike method-controlled display components, chatinput processes `tea.KeyMsg` in `Update()` directly
+- **Submit flow**: Enter emits `SubmitMsg{Text, AutoAccept, PlanMode}`; Alt+Enter / Ctrl+J inserts newline; Esc clears input
+- **History navigation**: Up/Down arrows navigate history buffer (size 100 by default); draft saved when entering history, restored on exit
+- **Clipboard**: Ctrl+Y or Ctrl+Shift+C triggers `CopyCmd()` using OSC 52 escape sequences; works over SSH/tmux/Wayland; emits `CopiedMsg{Text, Err}`
+- **Flash animation**: Border flashes `flashBorderColor` for `flashDuration` (default 150ms) on copy; respects `REDUCE_MOTION` env var via `accessibility.ReduceMotion()`
+- **Auto-expanding height**: `Height()` clamps `LineCount()` between `minHeight` (default 1) and `maxHeight` (default 10); `View()` intentionally mutates textarea height for this
+- **Custom placeholder**: Rendered manually (not via bubbles textarea) to work around a bug where the first placeholder line does not fill the background
+- **Info bar layout**: `[indent][Mode] [InfoBar]  ...spacing...  [Counter]`; indent width matches prompt width for alignment
+- **Responsive sizing**: Implements `SetSize(width, height int)` pattern; parent handles `tea.WindowSizeMsg` and calls `SetWidth()`
+- **Focus state**: Embeds `focus.State`; `Focus()` and `Blur()` override to also delegate to the internal textarea
 
 ### VHS Visual Regression Testing Pattern
 - **Location**: Tape files co-located with examples (`example/<component>/<component>.tape`)


### PR DESCRIPTION
## Summary

- Rewrites `/tdd` and `/tdd-review` slash commands to use `TeamCreate` + shared `TaskList` + `SendMessage` self-coordination pattern, replacing fire-and-forget parallel agents
- Teammates autonomously check TaskList, filter by role, claim lowest-ID unblocked tasks, and loop - lead monitors and intervenes only for review dispatch, escalation, and stale state
- Includes pending CLAUDE.md auto-memory update for chatinput component patterns

## Test plan

- [ ] Invoke `/tdd-review` on existing code to verify team lifecycle (create, spawn reviewers, collect results, cleanup)
- [ ] Invoke `/tdd <issue>` on a test issue to verify full TDD cycle with self-coordination
- [ ] Verify `~/.claude/teams/` and `~/.claude/tasks/` directories are cleaned up after completion
- [ ] Verify quick mode (`/tdd-review --quick`) uses single agent without team creation